### PR TITLE
Update work experience: add Traba, update Two Sigma

### DIFF
--- a/content/jobs/Traba/index.md
+++ b/content/jobs/Traba/index.md
@@ -1,0 +1,10 @@
+---
+date: '2025-05-01'
+title: 'Software Engineer'
+company: 'Traba'
+location: 'New York City, NY'
+range: 'May 2025 - Present'
+url: 'https://www.traba.work'
+---
+
+- Working in the Agents team, building and scaling Scout, Traba's AI-powered worker vetting agent ([read about it here](https://traba.work/company/engineering/building-scout)).

--- a/content/jobs/Two Sigma/index.md
+++ b/content/jobs/Two Sigma/index.md
@@ -1,10 +1,15 @@
 ---
 date: '2021-08-09'
-title: 'Software Engineer'
+title: 'Machine Learning Engineer'
 company: 'Two Sigma'
 location: 'London, UK'
-range: 'Aug 2021 - Present'
+range: 'Aug 2021 - May 2025'
 url: 'https://www.twosigma.com'
 ---
 
-Working in the AI Engineering team
+- Designed and implemented a Ray-based distributed compute framework that optimizes data locality, resulting in 3x faster Machine Learning research workflows with 50% compute cost reduction.
+- Developed and maintained a core library for efficient and reliable model serialization and transfer, streamlining firm-wide model productionization and unlocking regular automated model refits and releases.
+- Led the design and implementation of solutions to export 80% of Two Sigma's primary time-series forecasting library's models to production, used by multiple research teams.
+- Engineered a one-click system to perform simulations, backtesting and analysis on regularly retrained models.
+- Collaborated with ML researchers to develop custom solutions and integrate proprietary ML techniques into our forecasting library.
+- Reduced test times for a proprietary distributed compute framework by 85%.

--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -125,7 +125,7 @@ const About = () => {
     sr.reveal(revealContainer.current, srConfig());
   }, []);
 
-  const skills = ['Python', 'Java', 'C, C++', 'SML', 'SQL', 'R'];
+  const skills = ['TypeScript', 'Python', 'NestJS', 'PostgreSQL', 'Redis', 'Kafka'];
 
   return (
     <StyledAboutSection id="about" ref={revealContainer}>
@@ -136,8 +136,7 @@ const About = () => {
           <div>
             <p>
               Hello! I'm Shiv Godhia, a Software Engineer{' '}
-              <a href="https://www.twosigma.com">@Two Sigma</a> where I work on engineering
-              challenges in Machine Learning.
+              <a href="https://www.traba.work">@Traba</a> on the AI Agents team.
             </p>
 
             <p>

--- a/src/components/sections/hero.js
+++ b/src/components/sections/hero.js
@@ -66,10 +66,14 @@ const Hero = () => {
     <>
       <p>
         I'm a Software Engineer working{' '}
+        <a href="https://www.traba.work" target="_blank" rel="noreferrer">
+          @Traba
+        </a>
+        . Previously, I worked{' '}
         <a href="https://www.twosigma.com" target="_blank" rel="noreferrer">
           @Two Sigma
         </a>
-        . Previously, I studied Computer Science{' '}
+        , studied Computer Science{' '}
         <a href="https://www.cam.ac.uk/" target="_blank" rel="noreferrer">
           @University of Cambridge
         </a>{' '}


### PR DESCRIPTION
## Summary
- Add Traba (May 2025 - Present) as current role on the AI Agents team, with link to Scout blog post
- Update Two Sigma to Aug 2021 - May 2025 with detailed bullet points
- Update hero and about sections to reference Traba as current employer
- Update skills list to reflect current tech stack

[checklist-validation-start]
## QA Checklist
- [x] Content updates verified locally
[checklist-validation-end]

[test-validation-start]
## Test Plan
- [x] Verified dev server renders updated content correctly
[test-validation-end]