### PR TITLE
Add GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - run: npm install --legacy-peer-deps
+
+      - run: npx gatsby build
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: master
+          cname: www.shivgodhia.com


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that auto-deploys to GitHub Pages on push to main
- Builds with Gatsby and publishes the public/ directory to the master branch
- Preserves the custom CNAME (www.shivgodhia.com)

[checklist-validation-start]
## QA Checklist
- [x] Workflow syntax validated
- [x] Matches existing manual deploy process (gatsby build + gh-pages to master)
[checklist-validation-end]

[test-validation-start]
## Test Plan
- [x] Will verify on merge by checking the Actions tab for a successful run
[test-validation-end]