### PR TITLE
Fix deploy workflow: remove npm cache requirement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: npm
 
       - run: npm install --legacy-peer-deps
 


### PR DESCRIPTION
## Summary
- Removes the npm cache option from setup-node since the repo has no package-lock.json
- Fixes the failing deploy action

[checklist-validation-start]
## QA Checklist
- [x] Root cause identified: no lockfile in repo
[checklist-validation-end]

[test-validation-start]
## Test Plan
- [x] Will verify via Actions tab after merge
[test-validation-end]