### PR TITLE
Fix build: remove projects source-filesystem config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -50,13 +50,6 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `projects`,
-        path: `${__dirname}/content/projects`,
-      },
-    },
-    {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [


### PR DESCRIPTION
The previous PR removed the content/projects directory but left the gatsby-source-filesystem config pointing to it, causing the build to fail.

[checklist-validation-start]
- [x] Build fix
[checklist-validation-end]

[test-validation-start]
- [ ] Verify gatsby build succeeds
[test-validation-end]